### PR TITLE
Add PEP-561 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ module = SourceFileLoader(
     "version", os.path.join("aiohttp_s3_client", "version.py")
 ).load_module("version")
 
+packages = find_packages(exclude=["tests"])
+package_data = {package: ['py.typed'] for package in packages}
 
 setup(
     name="aiohttp-s3-client",
@@ -37,7 +39,8 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    packages=find_packages(exclude=["tests"]),
+    packages=packages,
+    package_data=package_data,
     install_requires=[
         "aiomisc~=14.4", "aiohttp<4", "aws-request-signer==1.0.0",
     ],


### PR DESCRIPTION
Hi! I have tried to use your library and noticed that mypy cannot check types correctly because the library is not [pep-561](https://www.python.org/dev/peps/pep-0561/) compatible. This PR adds the compatibility. 