### PR TITLE
Bump aiomisc, fix etag handling

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -47,6 +47,8 @@ jobs:
           - py37
           - py38
           - py39
+          - py310
+          - py311
 
     steps:
       - uses: actions/checkout@v2

--- a/aiohttp_s3_client/client.py
+++ b/aiohttp_s3_client/client.py
@@ -634,7 +634,7 @@ class S3Client:
                     f"Got response for HEAD request for {object_name}"
                     f"of a wrong status {resp.status}",
                 )
-            etag = resp.headers["Etag"].strip('"')
+            etag = resp.headers["Etag"]
             file_size = int(resp.headers["Content-Length"])
             log.debug(
                 "Object's %s etag is %s and size is %d",

--- a/aiohttp_s3_client/client.py
+++ b/aiohttp_s3_client/client.py
@@ -124,8 +124,8 @@ ParamsType = t.Optional[t.Mapping[str, str]]
 class S3Client:
     def __init__(
         self, session: ClientSession, url: URL,
-        secret_access_key: str = None,
-        access_key_id: str = None,
+        secret_access_key: t.Optional[str] = None,
+        access_key_id: t.Optional[str] = None,
         region: str = "",
     ):
         access_key_id = access_key_id or url.user
@@ -155,11 +155,11 @@ class S3Client:
 
     def request(
         self, method: str, path: str,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
         params: ParamsType = None,
         data: t.Optional[DataType] = None,
         data_length: t.Optional[int] = None,
-        content_sha256: str = None,
+        content_sha256: t.Optional[str] = None,
         **kwargs,
     ) -> RequestContextManager:
         if isinstance(data, bytes):
@@ -247,8 +247,8 @@ class S3Client:
     def put_file(
         self, object_name: t.Union[str, Path],
         file_path: t.Union[str, Path],
-        *, headers: HeadersType = None,
-        chunk_size: int = CHUNK_SIZE, content_sha256: str = None,
+        *, headers: t.Optional[HeadersType] = None,
+        chunk_size: int = CHUNK_SIZE, content_sha256: t.Optional[str] = None,
     ) -> RequestContextManager:
 
         headers = self._prepare_headers(headers, str(file_path))
@@ -270,7 +270,7 @@ class S3Client:
     async def _create_multipart_upload(
         self,
         object_name: str,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
     ) -> str:
         async with self.post(
             object_name,
@@ -372,7 +372,7 @@ class S3Client:
         object_name: t.Union[str, Path],
         file_path: t.Union[str, Path],
         *,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
         part_size: int = PART_SIZE,
         workers_count: int = 1,
         max_size: t.Optional[int] = None,
@@ -434,7 +434,7 @@ class S3Client:
         object_name: t.Union[str, Path],
         data: t.Iterable[bytes],
         *,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
         workers_count: int = 1,
         max_size: t.Optional[int] = None,
         part_upload_tries: int = 3,
@@ -523,7 +523,7 @@ class S3Client:
         req_range_start: int,
         req_range_end: int,
         buffer_size: int,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
         **kwargs,
     ):
         """
@@ -566,7 +566,7 @@ class S3Client:
         range_end: int,
         buffer_size: int,
         range_get_tries: int = 3,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
         **kwargs,
     ):
         """
@@ -607,7 +607,7 @@ class S3Client:
         object_name: t.Union[str, Path],
         file_path: t.Union[str, Path],
         *,
-        headers: HeadersType = None,
+        headers: t.Optional[HeadersType] = None,
         range_step: int = PART_SIZE,
         workers_count: int = 1,
         range_get_tries: int = 3,
@@ -700,7 +700,7 @@ class S3Client:
         object_name: t.Union[str, Path] = "/",
         *,
         bucket: t.Optional[str] = None,
-        prefix: t.Union[str, Path] = None,
+        prefix: t.Optional[t.Union[str, Path]] = None,
         delimiter: t.Optional[str] = None,
         max_keys: t.Optional[int] = None,
         start_after: t.Optional[str] = None,

--- a/aiohttp_s3_client/version.py
+++ b/aiohttp_s3_client/version.py
@@ -13,7 +13,7 @@ package_license = "Apache Software License"
 
 team_email = "me@mosquito.su"
 
-version_info = (0, 7, 1)
+version_info = (0, 7, 2)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             "coverage!=4.3",
             "coveralls",
             "mypy",
-            "pylava",
+            "pylama",
             "pytest",
             "pytest-aiohttp",
             "pytest-cov",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=packages,
     package_data=package_data,
     install_requires=[
-        "aiomisc<18,>=14", "aiohttp<4", "aws-request-signer==1.0.0",
+        "aiomisc~=17.0", "aiomisc-pytest~=1.1", "aiohttp<4", "aws-request-signer==1.0.0",
     ],
     python_requires=">3.7.*, <4",
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,12 @@ setup(
     packages=packages,
     package_data=package_data,
     install_requires=[
-        "aiomisc<17,>=14", "aiohttp<4", "aws-request-signer==1.0.0",
+        "aiomisc<18,>=14", "aiohttp<4", "aws-request-signer==1.0.0",
     ],
     python_requires=">3.7.*, <4",
     extras_require={
         "develop": [
+            "aiomisc-pytest~=1.1",
             "coverage!=4.3",
             "coveralls",
             "mypy",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from aiohttp_s3_client import S3Client
 
 
 @pytest.fixture
-async def s3_client(loop, s3_url: URL):
+async def s3_client(event_loop, s3_url: URL):
     async with ClientSession(
         raise_for_status=False, auto_decompress=False,
     ) as session:

--- a/tests/test_get_file_parallel.py
+++ b/tests/test_get_file_parallel.py
@@ -71,6 +71,6 @@ async def test_get_file_that_changed_in_process_error(
 
     assert err.type is AwsDownloadError
     assert err.value.args[0].startswith(
-        "Got wrong status code 416 on range download of test/test",
+        "Got wrong status code 412 on range download of test/test",
     )
     assert not os.path.exists(tmpdir / "temp.dat")

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,10 @@ commands=
 
 [testenv:lint]
 deps =
-    pylava
+    pylama
 
 commands=
-    pylava -o pylava.ini aiohttp_s3_client tests
+    pylama -o pylama.ini aiohttp_s3_client tests
 
 [testenv:typecheck]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py3{7-9}
+envlist = lint,py3{7-11}
 
 [testenv]
 extras =


### PR DESCRIPTION
According to [RFC 7232](https://www.rfc-editor.org/rfc/rfc7232) etag should always be quoted:
```
entity-tag = [ weak ] opaque-tag
weak       = %x57.2F ; "W/", case-sensitive
opaque-tag = DQUOTE *etagc DQUOTE
etagc      = %x21 / %x23-7E / obs-text
            ; VCHAR except double quotes, plus obs-text
```