### PR TITLE
Add copy/rename; Content-Type inference; tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ async with ClientSession(raise_for_status=True) as session:
     async with client.delete("bucket/key") as resp:
         assert resp == HTTPStatus.NO_CONTENT
 
+    # Copy object (server-side) within/between buckets
+    async with client.copy("bucket/src.txt", "bucket/dst.txt") as resp:
+        assert resp.status == HTTPStatus.OK
+
+    # Rename (copy then delete source)
+    await client.rename("bucket/old-key", "bucket/new-key")
+
     # List objects by prefix
     async for result, prefixes in client.list_objects_v2("bucket/", prefix="prefix"):
         # Each result is a list of metadata objects representing an object
@@ -271,6 +278,13 @@ await client.put_file_multipart(
     },
     workers_count=8,
 )
+
+### Content-Type inference
+
+When uploading (including multipart initiation), if you do not provide a
+`Content-Type` header explicitly, the client infers it from the provided
+file path or object key using Python's `mimetypes` and falls back to
+`application/octet-stream`.
 ```
 
 ## Parallel download to file


### PR DESCRIPTION
This pull request introduces several improvements and new features to the S3 client, with a particular focus on content-type inference, object operations (copy and rename), and code readability. The most notable changes are the addition of server-side copy and rename operations, automatic content-type inference for uploads, and refactoring for better maintainability and clarity.

### New S3 Object Operations

* Added a new `copy` method to `S3Client` that performs server-side object copying within or between buckets using the S3 `CopyObject` API. This method supports metadata replacement and content-type updates.
* Introduced a `rename` method to `S3Client`, which moves an object by copying it to a new key and then deleting the source. This operation is non-atomic and handles error reporting.
* Updated the `README.md` to document the new `copy` and `rename` operations with example usage.

### Content-Type Inference

* Implemented automatic `Content-Type` inference for uploads (including multipart) using Python's `mimetypes` library, falling back to `application/octet-stream` if the type cannot be determined. This is applied in `put`, `post`, `put_file`, `put_file_multipart`, and `put_multipart` methods. 
* Added documentation in `README.md` describing how content-type inference works and when it is applied.