### PR TITLE
Backport features from #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,68 @@ async with client.put(
     ...
 ```
 
+## Custom metadata
+
+S3 allows you to attach arbitrary key-value metadata to objects using
+`x-amz-meta-<key>` headers. You can pass these via the `headers` parameter
+on any upload method.
+
+With `client.put()`:
+
+```python
+async with client.put(
+    "bucket/report.json",
+    b'{"result": 42}',
+    headers={
+        "x-amz-meta-author": "alice",
+        "x-amz-meta-version": "3",
+    },
+) as resp:
+    assert resp.status == 200
+```
+
+With `client.put_file()`:
+
+```python
+resp = await client.put_file(
+    "bucket/photo.jpg",
+    "/path/to/photo.jpg",
+    headers={
+        "x-amz-meta-camera": "Nikon D850",
+        "x-amz-meta-location": "Paris",
+    },
+)
+```
+
+With `client.put_file_multipart()`:
+
+```python
+await client.put_file_multipart(
+    "bucket/bigfile.csv",
+    "/path/to/bigfile.csv",
+    headers={
+        "Content-Type": "text/csv",
+        "x-amz-meta-source": "etl-pipeline",
+    },
+    workers_count=8,
+)
+```
+
+Metadata can also be set or replaced during a server-side copy by passing
+`replace_metadata=True`:
+
+```python
+async with client.copy(
+    "bucket/src-key",
+    "bucket/dst-key",
+    replace_metadata=True,
+    headers={
+        "x-amz-meta-status": "archived",
+    },
+) as resp:
+    assert resp.status == 200
+```
+
 ## Parallel download to file
 
 S3 supports `GET` requests with `Range` header. It's possible to download

--- a/aiohttp_s3_client/client.py
+++ b/aiohttp_s3_client/client.py
@@ -53,11 +53,14 @@ EMPTY_STR_HASH = hashlib.sha256(b"").hexdigest()
 PART_SIZE = 5 * 1024 * 1024  # 5MB
 
 if sys.version_info >= (3, 13):
+
     def _guess_content_type(path: str) -> str | None:
         return mimetypes.guess_file_type(path)[0]
 else:
+
     def _guess_content_type(path: str) -> str | None:
         return mimetypes.guess_type(path)[0]
+
 
 HeadersType = dict | CIMultiDict | CIMultiDictProxy
 
@@ -243,10 +246,15 @@ class S3Client:
         **kwargs,
     ) -> RequestContextManager:
         headers = self._prepare_headers(
-            kwargs.pop("headers", None), object_name,
+            kwargs.pop("headers", None),
+            object_name,
         )
         return self.request(
-            "PUT", object_name, data=data, headers=headers, **kwargs,
+            "PUT",
+            object_name,
+            data=data,
+            headers=headers,
+            **kwargs,
         )
 
     def post(
@@ -256,10 +264,15 @@ class S3Client:
         **kwargs,
     ) -> RequestContextManager:
         headers = self._prepare_headers(
-            kwargs.pop("headers", None), object_name,
+            kwargs.pop("headers", None),
+            object_name,
         )
         return self.request(
-            "POST", object_name, data=data, headers=headers, **kwargs,
+            "POST",
+            object_name,
+            data=data,
+            headers=headers,
+            **kwargs,
         )
 
     async def put_file(
@@ -758,7 +771,8 @@ class S3Client:
         headers = self._prepare_headers(headers, destination)
         source_url = self._url / source.lstrip("/")
         headers["x-amz-copy-source"] = quote(
-            source_url.path, safe="/",
+            source_url.path,
+            safe="/",
         )
         if replace_metadata:
             headers["x-amz-metadata-directive"] = "REPLACE"
@@ -790,7 +804,10 @@ class S3Client:
         headers: additional headers forwarded to ``copy()``
         """
         async with self.copy(
-            source, destination, headers=headers, **kwargs,
+            source,
+            destination,
+            headers=headers,
+            **kwargs,
         ) as resp:
             if resp.status != HTTPStatus.OK:
                 payload = await resp.text()
@@ -801,7 +818,8 @@ class S3Client:
 
         async with self.delete(source) as resp:
             if resp.status not in (
-                HTTPStatus.OK, HTTPStatus.NO_CONTENT,
+                HTTPStatus.OK,
+                HTTPStatus.NO_CONTENT,
             ):
                 payload = await resp.text()
                 raise AwsError(


### PR DESCRIPTION
This pull request adds support for server-side copy and rename operations to the S3 client, and introduces automatic Content-Type inference when uploading objects. It also includes comprehensive tests for the new features and ensures compatibility with Python 3.13+. The most important changes are grouped below:

### New S3 Operations

* Added a `copy` method to the client for efficient server-side copying of objects, including options for metadata replacement and Content-Type overrides.
* Added a `rename` method that moves objects by copying to a new key and deleting the source, with error handling for non-atomic operations.
* Updated the documentation and usage examples in `README.md` to demonstrate the new `copy` and `rename` methods.

### Content-Type Inference

* Implemented automatic inference of the `Content-Type` header for uploads using Python's `mimetypes` module, with a fallback to `application/octet-stream` and an option to override. This logic is compatible with Python 3.13+. [[1]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064R4-R5) [[2]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064L14) [[3]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064R55-R61) [[4]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064L211-R231) [[5]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064L230-R263) [[6]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064R352-R353) [[7]](diffhunk://#diff-daf67a60c312511ecf408ba9ea8c761f9987fe23cb46b0d5e843286807a77064R429-R430)
* Added documentation to `README.md` explaining Content-Type inference and how to override it.

### Testing

* Added tests for the new `copy` and `rename` methods to verify correct behavior and error handling.